### PR TITLE
Print a better error message when attempting to bridge from void to void

### DIFF
--- a/injector/src/main/java/com/infradna/tool/bridge_method_injector/MethodInjector.java
+++ b/injector/src/main/java/com/infradna/tool/bridge_method_injector/MethodInjector.java
@@ -231,6 +231,8 @@ public class MethodInjector {
                     if (returnType.equals(Type.VOID_TYPE) || returnType.getClassName().equals("java.lang.Void")) {
                         // bridge to void, which means disregard the return value from the original method
                         switch (originalReturnType.getSize()) {
+                        case 0:
+                            throw new IllegalArgumentException("Cannot bridge " + name + " from void to void; did you mean to use a different type?");
                         case 1:
                             mv.visitInsn(POP);
                             break;


### PR DESCRIPTION
#9 describes a bad error message: when attempting to bridge from void to void, an assertion is tripped rather than a nice error message being given. I reproduced this locally. With this fix there is a better error message. Unfortunately the test framework does not lend itself to this type of negative testing so I could not write an automated test.

Fixes #9