### PR TITLE
`@WithBridgeMethods(void.class)` could produce better code

### DIFF
--- a/injector/src/main/java/com/infradna/tool/bridge_method_injector/MethodInjector.java
+++ b/injector/src/main/java/com/infradna/tool/bridge_method_injector/MethodInjector.java
@@ -223,7 +223,7 @@ public class MethodInjector {
                     if (hasAdapterMethod()) {
                         insertAdapterMethod(ga);
                     } else
-                    if (castRequired) {
+                    if (castRequired || returnType.equals(Type.VOID_TYPE)) {
                         ga.unbox(returnType);
                     } else {
                         ga.box(originalReturnType);

--- a/injector/src/test/client/Main.java
+++ b/injector/src/test/client/Main.java
@@ -1,8 +1,23 @@
 public class Main {
     public static void main(String[] args) throws Exception {
         // invocation of void method. verify that it runs without error
+
+        Foo.toggle = false;
         Foo.hello();
+        assertEquals(true, Foo.toggle);
+
+        Foo.toggle = false;
         Foo.hello2();
+        assertEquals(true, Foo.toggle);
+
+        Foo.toggle = false;
+        new Foo().hello3();
+        assertEquals(true, Foo.toggle);
+
+        Foo.toggle = false;
+        new Foo().hello4();
+        assertEquals(true, Foo.toggle);
+
         Foo.unbox();
         Foo.box();
 

--- a/injector/src/test/v1/Foo.java
+++ b/injector/src/test/v1/Foo.java
@@ -21,9 +21,23 @@ public class Foo implements IFoo {
       return clazz.cast("foo");
     }
 
-    public static void hello() {}
+    static boolean toggle;
 
-    public static void hello2() {}
+    public static void hello() {
+        toggle = true;
+    }
+
+    public static void hello2() {
+        toggle = true;
+    }
+
+    public void hello3() {
+        toggle = true;
+    }
+
+    public void hello4() {
+        toggle = true;
+    }
     
     public static int unbox() {return Integer.MIN_VALUE;}
     

--- a/injector/src/test/v2/Foo.java
+++ b/injector/src/test/v2/Foo.java
@@ -24,14 +24,30 @@ public class Foo implements IFoo {
       return clazz.cast("bar");
     }
 
+    static boolean toggle;
+
     @WithBridgeMethods(void.class)
     public static boolean hello() {
+        toggle = true;
         return true;
     }
 
     @WithBridgeMethods(void.class)
     public static String hello2() {
+        toggle = true;
         return "hello2";
+    }
+
+    @WithBridgeMethods(void.class)
+    public boolean hello3() {
+        toggle = true;
+        return true;
+    }
+
+    @WithBridgeMethods(void.class)
+    public String hello4() {
+        toggle = true;
+        return "hello4";
     }
     
     @WithBridgeMethods(value=int.class, castRequired=true)


### PR DESCRIPTION
This PR adds a few new tests that expose the problem, not by the test failing but rather by generating the inefficient code and successfully executing it. The change to `injector/src/main/` fixes the problem by optimizing the bytecode as described in the bug. Since the test passes before and after, we know there are no regressions. By inspecting the bytecode before and after this PR I confirmed that it was optimized as described in the bug.

Fixes #10