### PR TITLE
Support Java 19+

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,6 @@
  * allowing one to test against multiple Jenkins versions.
  */
 buildPlugin(useContainerAgent: true, configurations: [
-  [ platform: 'linux', jdk: '11' ],
-  [ platform: 'windows', jdk: '11' ],
-  [ platform: 'linux', jdk: '17' ],
+  [platform: 'linux', jdk: 21],
+  [platform: 'windows', jdk: 17],
 ])

--- a/injector/pom.xml
+++ b/injector/pom.xml
@@ -97,7 +97,8 @@
                 <!-- basic sanity. unmodified client and v1 should work as expected -->
                 <javac destdir="target/test-classes/v1" includeantruntime="false" release="${maven.compiler.release}" srcdir="src/test/v1" />
                 <javac classpath="target/test-classes/v1" destdir="target/test-classes/client" includeantruntime="false" release="${maven.compiler.release}" srcdir="src/test/client" />
-                <java classname="Main" failonerror="true">
+                <java classname="Main" failonerror="true" fork="true">
+                  <sysproperty key="java.security.manager" value="allow" />
                   <arg value="foo" />
                   <classpath>
                     <pathelement path="target/test-classes/v1" />
@@ -115,13 +116,15 @@
                 </javac>
 
                 <!-- post process v2 -->
-                <java classname="com.infradna.tool.bridge_method_injector.MethodInjector" failonerror="true">
+                <java classname="com.infradna.tool.bridge_method_injector.MethodInjector" failonerror="true" fork="true">
+                  <sysproperty key="java.security.manager" value="allow" />
                   <arg value="${project.basedir}/target/test-classes/v2" />
                   <classpath refid="maven.compile.classpath" />
                 </java>
 
                 <!-- verify that unmodified client code continue to work with v2 binary -->
-                <java classname="Main" failonerror="true">
+                <java classname="Main" failonerror="true" fork="true">
+                  <sysproperty key="java.security.manager" value="allow" />
                   <arg value="bar" />
                   <classpath>
                     <pathelement path="target/test-classes/v2" />
@@ -139,7 +142,8 @@
                 </javac>
 
                 <!-- post process synthetics -->
-                <java classname="com.infradna.tool.bridge_method_injector.MethodInjector" failonerror="true">
+                <java classname="com.infradna.tool.bridge_method_injector.MethodInjector" failonerror="true" fork="true">
+                  <sysproperty key="java.security.manager" value="allow" />
                   <arg value="${project.basedir}/target/test-classes/synthetics" />
                   <classpath refid="maven.compile.classpath" />
                 </java>
@@ -152,7 +156,8 @@
                     <pathelement path="target/test-classes/v2" />
                   </classpath>
                 </javac>
-                <java classname="Main" failonerror="true">
+                <java classname="Main" failonerror="true" fork="true">
+                  <sysproperty key="java.security.manager" value="allow" />
                   <arg value="bar" />
                   <classpath>
                     <pathelement path="target/test-classes/v2" />

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.115</version>
+    <version>1.116</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
The test suite uses Ant to run the tests, and Ant currently requires a security manager, which is disabled by default on Java 19+ (see [bug 575210](https://bugs.eclipse.org/bugs/show_bug.cgi?id=575210)). This PR works around the problem by re-enabling the security manager when running the tests with Ant. I tested this by running the tests with Java 20, both with and without `maven.compiler.release=20`.